### PR TITLE
Allow negative altitude and fix config parameters

### DIFF
--- a/base/accessory.js
+++ b/base/accessory.js
@@ -84,7 +84,7 @@ class SunAzimuthAccessory {
 
     const sunPos = suncalc.getPosition(Date.now(), lat, long);
     let sunPosDegrees = Math.abs((sunPos.azimuth * 180) / Math.PI + 180);
-    let sunPosAltitude = Math.abs(sunPos.altitude * 90);
+    let sunPosAltitude = Math.abs(sunPos.altitude * 90 / (Math.PI / 2));
 
     if (platformConfig.debugLog)
       log(`${name}: Current azimuth: ${sunPosDegrees}°, altitude: ${sunPosAltitude}°`);

--- a/base/accessory.js
+++ b/base/accessory.js
@@ -84,7 +84,7 @@ class SunAzimuthAccessory {
 
     const sunPos = suncalc.getPosition(Date.now(), lat, long);
     let sunPosDegrees = Math.abs((sunPos.azimuth * 180) / Math.PI + 180);
-    let sunPosAltitude = Math.abs(sunPos.altitude * 90 / (Math.PI / 2));
+    let sunPosAltitude = sunPos.altitude * 90 / (Math.PI / 2);
 
     if (platformConfig.debugLog)
       log(`${name}: Current azimuth: ${sunPosDegrees}°, altitude: ${sunPosAltitude}°`);

--- a/config.schema.json
+++ b/config.schema.json
@@ -69,22 +69,28 @@
                             "type": "number",
                             "title": "Lower Threshold",
                             "description": "Left side of sky section within which the sensor should activate",
-                            "required": true
+                            "required": true,
+                            "default": 0,
+                            "minimum": -360,
+                            "maximum": 720
                         },
                         "upperThreshold": {
                             "type": "number",
                             "title": "Upper Threshold",
                             "description": "Right side of sky section within which the sensor should activate",
-                            "required": true
+                            "required": true,
+                            "default": 0,
+                            "minimum": -360,
+                            "maximum": 720
                         },
                         "minimumTemperatureCelsuisConsideredSunny": {
                             "type": "number",
                             "title": "Minimum temperature in °C which is considered sunny",
-                            "description": "Sets a minimum temperature that is required so that the sensor can be activated. If the temperature stays below this value, the sensor will not activate which allows automated windows blinds to stay open on cold days. Only available if an OpenWeather API key is defined and weather integration is enabled.",
+                            "description": "Sets a minimum temperature that is required so that the sensor can be activated. If the temperature stays below this value, the sensor will not activate which allows automated windows blinds to stay closed on cold days. Only available if an OpenWeather API key is defined and weather integration is enabled.",
                             "required": true,
                             "default": 20,
-                            "minimum": 0,
-                            "maximum": 100
+                            "minimum": -40,
+                            "maximum": 50
                         },
                         "lowerAltitudeThreshold": {
                             "type": "number",
@@ -92,8 +98,8 @@
                             "description": "Lower altitude threshold for the sun's position above the horizon, above which the sensor should activate. The threshold is measured in degrees, with 0° being on the horizon and 90° being at the zenith.",
                             "required": true,
                             "default": 0,
-                            "minimum": 0,
-                            "maximum": 360
+                            "minimum": -90,
+                            "maximum": 90
                         },
                         "upperAltitudeThreshold": {
                             "type": "number",
@@ -101,8 +107,8 @@
                             "description": "Upper altitude threshold for the sun's position above the horizon, below which the sensor should activate. The threshold is measured in degrees, with 0° being on the horizon and 90° being at the zenith.",
                             "required": true,
                             "default": 90,
-                            "minimum": 0,
-                            "maximum": 360
+                            "minimum": -90,
+                            "maximum": 90
                         }
                     }
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-sun-azimuth",
-  "version": "0.3.10",
+  "version": "0.3.11-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-sun-azimuth",
-      "version": "0.3.10",
+      "version": "0.3.11-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "request": "^2.88.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-sun-azimuth",
   "displayName": "Homebridge Sun Azimuth",
-  "version": "0.3.10",
+  "version": "0.3.11-beta.1",
   "description": "Homebridge plugin for contact sensors monitoring sun position, daylight and cloudiness",
   "author": "awaescher",
   "contributors": [
@@ -12,6 +12,10 @@
     {
       "name": "Christian Wegerhoff",
       "email": "christian.wegerhoff@icloud.com"
+    },
+    {
+      "name": "Michael Weinand",
+      "email": "opensource@michaelweinand.consulting"
     }
   ],
   "engines": {


### PR DESCRIPTION
This does a few things:

- Builds on https://github.com/awaescher/homebridge-sun-azimuth/pull/2
- Removes the absolute value math on altitude. Altitude is a negative value at night. By doing the absolute value, it inadvertantly can trigger the sensor to true while the sun is below the horizon.
- Fixes min and max values for config parameters. It is very common to have negative celsius temperatures.